### PR TITLE
QA-4388 Fixes in append scenario

### DIFF
--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -83,8 +83,10 @@
       r
       (do (log/info "Failed attempt" (str attempt "/" max-attempts) "for" op)
           (if-not (< attempt max-attempts)
-            nil
-            (recur (inc attempt)))))))
+            (throw (RuntimeException. (str "Await exhausted after " max-attempts " attempts")))
+            (do
+              (Thread/sleep 50)
+              (recur (inc attempt))))))))
 
 (defrecord Client [^Ignite ignite]
   client/Client

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -34,8 +34,8 @@
   "Perform a single operation in separate transaction."
   (let [txn (.begin (.transactions ignite))
         sql (.sql ignite)]
-    (if
-      (= :r opcode)
+    (case opcode
+      :r
       (let [select-result
               (with-open [session  (.createSession sql)
                           rs       (run-sql session txn sql-select [k])]
@@ -48,6 +48,7 @@
                   []))]
         (.commit txn)
         [:r k select-result])
+      :append
       (with-open [session   (.createSession sql)
                   read-rs   (run-sql session txn sql-select [k])]
         (if (.hasNext read-rs)

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -75,9 +75,7 @@
     (if-let [r (try
                  (invoke-op ignite op)
                  (catch TransactionException te
-                   (if (.contains (.getMessage te) "Replication is timed out")
-                     nil
-                     (throw te)))
+                   (log/warn "TransactionException:" (.getMessage te)))
                  (catch IgniteException ie
                    (if (.contains (.getMessage ie) "Failed to acquire a lock")
                      nil

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -30,7 +30,7 @@
     (log/info query params)
     (.execute session txn query (object-array params))))
 
-(defn read! [ignite txn [opcode k v]]
+(defn read! [ignite txn [_ k _]]
   "Read value to the table by key, as list of numbers."
   (let [r (with-open [session   (.createSession (.sql ignite))
                       rs        (run-sql session txn sql-select [k])]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -12,7 +12,8 @@
             [jepsen.tests.cycle.append :as app])
   (:import (org.apache.ignite Ignite)
            (org.apache.ignite.client IgniteClient)
-           (org.apache.ignite.lang IgniteException)))
+           (org.apache.ignite.lang IgniteException)
+           (org.apache.ignite.tx TransactionException)))
 
 (def table-name "APPEND")
 
@@ -80,7 +81,11 @@
                  (catch IgniteException ie
                    (if (.contains (.getMessage ie) "Failed to acquire a lock")
                      nil
-                     (throw ie))))]
+                     (throw ie)))
+                 (catch TransactionException te
+                   (if (.contains (.getMessage te) "Replication is timed out")
+                     nil
+                     (throw te))))]
       r
       (do (log/info "Failed attempt" (str attempt "/" max-attempts) "for" op)
           (if-not (< attempt max-attempts)

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -75,7 +75,7 @@
     (if-let [r (try
                  (invoke-op ignite op)
                  (catch TransactionException te
-                   (log/warn "TransactionException:" (.getMessage te)))
+                   (log/info "TransactionException:" (.getMessage te)))
                  (catch IgniteException ie
                    (if (.contains (.getMessage ie) "Failed to acquire a lock")
                      nil

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -16,7 +16,7 @@
 
 (def table-name "APPEND")
 
-(def max-attempts 10)
+(def max-attempts 20)
 
 (def sql-create (str "create table if not exists " table-name "(key int primary key, vals varchar(1000))"))
 

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -39,6 +39,7 @@
                       rs        (run-sql session txn sql-select [k])]
             (let [s (if (.hasNext rs) (.stringValue (.next rs) 1) "")]
               (->> (clojure.string/split s #",")
+                 (remove #(.isEmpty %))
                  (map #(Integer/parseInt %))
                  (into []))))]
     [:r k r]))

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -75,7 +75,9 @@
     (if-let [r (try
                  (invoke-op ignite op)
                  (catch TransactionException te
-                   (log/warn "TransactionException:" (.getMessage te)))
+                   (if (.contains (.getMessage te) "Replication is timed out")
+                     nil
+                     (throw te)))
                  (catch IgniteException ie
                    (if (.contains (.getMessage ie) "Failed to acquire a lock")
                      nil

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -32,15 +32,12 @@
 
 (defn read! [ignite txn [opcode k v]]
   "Read value to the table by key, as list of numbers."
-  (let [r (with-open [session  (.createSession (.sql ignite))
-                      rs       (run-sql session txn sql-select [k])]
-            (if (.hasNext rs)
-              (let [raw-result (.stringValue (.next rs) 1)
-                    strings    (clojure.string/split raw-result #",")]
-                (->> strings
-                     (map #(Integer/parseInt %))
-                     (into [])))
-              []))]
+  (let [r (with-open [session   (.createSession (.sql ignite))
+                      rs        (run-sql session txn sql-select [k])]
+            (let [s (if (.hasNext rs) (.stringValue (.next rs) 1) "")]
+              (->> (clojure.string/split s #",")
+                 (map #(Integer/parseInt %))
+                 (into []))))]
     [:r k r]))
 
 (defn append! [ignite txn [opcode k v]]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -40,9 +40,9 @@
                       rs        (run-sql session txn sql-select [k])]
             (let [s (if (.hasNext rs) (.stringValue (.next rs) 1) "")]
               (->> (clojure.string/split s #",")
-                 (remove #(.isEmpty %))
-                 (map #(Integer/parseInt %))
-                 (into []))))]
+                   (remove #(.isEmpty %))
+                   (map #(Integer/parseInt %))
+                   (into []))))]
     [:r k r]))
 
 (defn append! [ignite txn [opcode k v]]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -58,18 +58,12 @@
       (with-open [write-rs (run-sql session txn sql-insert [k (str v)])]))
     [opcode k v]))
 
-(defn invoke-in-tx! [^Ignite ignite txn op]
-  "Perform a single operation in a given transaction."
-  (case (first op)
-        :r
-        (read! ignite txn op)
-        :append
-        (append! ignite txn op)))
+(def select-op {:r read! :append append!})
 
 (defn invoke-op [^Ignite ignite op]
   "Perform a single operation in separate transaction."
   (let [txn (.begin (.transactions ignite))
-        result (invoke-in-tx! ignite txn op)]
+        result ((get select-op (first op)) ignite txn op)]
     (.commit txn)
     result))
 

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -72,14 +72,12 @@
   (loop [attempt 1]
     (if-let [r (try
                  (invoke-op ignite op)
+                 (catch TransactionException te
+                   (log/warn "TransactionException:" (.getMessage te)))
                  (catch IgniteException ie
                    (if (.contains (.getMessage ie) "Failed to acquire a lock")
                      nil
-                     (throw ie)))
-                 (catch TransactionException te
-                   (if (.contains (.getMessage te) "Replication is timed out")
-                     nil
-                     (throw te))))]
+                     (throw ie))))]
       r
       (do (log/info "Failed attempt" (str attempt "/" max-attempts) "for" op)
           (if-not (< attempt max-attempts)

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -63,10 +63,10 @@
 (defn invoke-ops [^Ignite ignite ops]
   "Perform operations in a transaction."
   (let [txn (.begin (.transactions ignite))
-        result (map #(case (first %)
-                       :r       (read! ignite txn %)
-                       :append  (append! ignite txn %))
-                    ops)]
+        result (mapv #(case (first %)
+                        :r       (read! ignite txn %)
+                        :append  (append! ignite txn %))
+                     ops)]
     (.commit txn)
     result))
 
@@ -130,7 +130,7 @@
 (def c (client/open! (Client. nil) {} "127.0.0.1"))
 (client/setup! c {})
 
-(client/invoke! c {} {:type :invoke, :process 0, :f :txn, :value [[:r 5 nil]]})
+(client/invoke! c {} {:type :invoke, :process 0, :f :txn, :value [[:r 5 nil] [:r 6 nil]]})
 
 (client/invoke! c {} {:type :invoke, :process 1, :f :txn, :value [[:append 9 2]]})
 

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -92,7 +92,6 @@
   client/Client
   ;
   (open! [this test node]
-    ; (log/info "Node: " node)
     (let [ignite (.build (.addresses (IgniteClient/builder) (into-array [(str node ":10800")])))]
       (assoc this :ignite ignite)))
   ;
@@ -103,13 +102,12 @@
       (log/info "Table" table-name "created")))
   ;
   (invoke! [this test op]
-    ; (log/info "Received: " op)
     (let [ops   (:value op)
+          ; result (map #(invoke-op ignite %) ops)
           result (map #(invoke-with-retries ignite %) ops)
           overall-result (assoc op
                                 :type :info
                                 :value (into [] result))]
-      ; (log/info "Returned: " overall-result)
       overall-result))
   ;
   (teardown! [this test])


### PR DESCRIPTION
1. Perform several operations in a single transaction.
2. Use retries on some "legal" exceptions.
3. Split complicated function into several smaller ones.