### PR TITLE
QA-4430 Append: do not retry a transaction on LockException after IGNITE-17811

### DIFF
--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -14,13 +14,13 @@
 (defn db-dir
   "Creates path to the DB main directory, or its subpath (items in 'more')."
   [test & more]
-  (clojure.string/join "/" (concat [server-dir (str "ignite3-db-" (:version test))]
+  (clojure.string/join "/" (concat [server-dir (str (:flavour test) "-db-" (:version test))]
                                    more)))
 
 (defn cli-dir
   "Creates path to the CLI main directory, or its subpath (items in 'more')."
   [test & more]
-  (clojure.string/join "/" (concat [server-dir (str "ignite3-cli-" (:version test))]
+  (clojure.string/join "/" (concat [server-dir (str (:flavour test) "-cli-" (:version test))]
                                    more)))
 
 (defn list-nodes

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -12,9 +12,7 @@
             [jepsen.tests.cycle.append :as app])
   (:import (org.apache.ignite Ignite)
            (org.apache.ignite.client IgniteClient RetryLimitPolicy)
-           (org.apache.ignite.lang IgniteException)
-           (org.apache.ignite.table.mapper Mapper)
-           (org.apache.ignite.tx TransactionException)))
+           (org.apache.ignite.table.mapper Mapper)))
 
 ; ---------- Common definitions ----------
 
@@ -114,25 +112,6 @@
     (.commit txn)
     result))
 
-(defn invoke-with-retries [^Ignite ignite acc ops]
-  "Perform operations with repeats on IgniteException, each time in a new transaction."
-  (loop [attempt 1]
-    (if-let [r (try
-                 (invoke-ops ignite acc ops)
-                 (catch TransactionException te
-                   (log/info "TransactionException:" (.getMessage te)))
-                 (catch IgniteException ie
-                   (if (.contains (.getMessage ie) "Failed to acquire a lock")
-                     nil
-                     (throw ie))))]
-      r
-      (do (log/info "Failed attempt" (str attempt "/" max-attempts) "for" ops)
-          (if-not (< attempt max-attempts)
-            (throw (RuntimeException. (str "Await exhausted after " max-attempts " attempts")))
-            (do
-              (Thread/sleep 50)
-              (recur (inc attempt))))))))
-
 (defn print-table-content [ignite]
   "Save resulting table content in the log."
   (with-open [session (.createSession (.sql ignite))
@@ -160,8 +139,7 @@
   ;
   (invoke! [this test op]
     (let [ops   (:value op)
-          ; result (invoke-ops ignite acc ops)
-          result (invoke-with-retries ignite acc ops)
+          result (invoke-ops ignite acc ops)
           overall-result (assoc op
                                 :type :info
                                 :value (into [] result))]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -11,7 +11,7 @@
                     [nemesis :as nemesis]]
             [jepsen.tests.cycle.append :as app])
   (:import (org.apache.ignite Ignite)
-           (org.apache.ignite.client IgniteClient)
+           (org.apache.ignite.client IgniteClient RetryLimitPolicy)
            (org.apache.ignite.lang IgniteException)
            (org.apache.ignite.table.mapper Mapper)
            (org.apache.ignite.tx TransactionException)))
@@ -146,7 +146,10 @@
   client/Client
   ;
   (open! [this test node]
-    (let [ignite (.build (.addresses (IgniteClient/builder) (into-array [(str node ":10800")])))]
+    (let [ignite (-> (IgniteClient/builder)
+                     (.addresses (into-array [(str node ":10800")]))
+                     (.retryPolicy (.retryLimit (RetryLimitPolicy.) 3))
+                     (.build))]
       (assoc this :ignite ignite)))
   ;
   (setup! [this test]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -127,7 +127,7 @@
   (open! [this test node]
     (let [ignite (-> (IgniteClient/builder)
                      (.addresses (into-array [(str node ":10800")]))
-                     (.retryPolicy (.retryLimit (RetryLimitPolicy.) 3))
+                     (.retryPolicy (RetryLimitPolicy.))
                      (.build))]
       (assoc this :ignite ignite)))
   ;

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -22,6 +22,9 @@
    ["-v" "--version VERSION"
     "What version of Apache Ignite to install"
     :default "3.0.0-SNAPSHOT"]
+   ["-f" "--flavour FLAVOUR"
+    "What flavour of product to install"
+    :default "ignite3"]
    ["-o" "--os NAME" "Operating system: either centos, debian, or noop."
     :default  :noop
     :parse-fn keyword


### PR DESCRIPTION
Instead of using custom `invoke-with-retries` function, we use `RetryLimitPolicy` when creating `IgniteClient` instance.