### PR TITLE
QA-4712 Add Nemesis to restart Ignite nodes during Append scenario

### DIFF
--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -112,9 +112,9 @@
   (->> generator
        (gen/stagger 1/10)
        (gen/nemesis
-         (cycle [(gen/sleep 5)
+         (cycle [(gen/sleep 30)
                  {:type :info, :f :start}
-                 (gen/sleep 1)
+                 (gen/sleep 30)
                  {:type :info, :f :stop}]))
        (gen/time-limit time-limit)))
 

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -64,6 +64,7 @@
 (defn stop!
   "Shuts down server."
   [node test]
+  (info node "Shutting down server node")
   (c/su
     (util/meh (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))))
 

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -66,12 +66,16 @@
                   (str "--meta-storage-node=" (node-name (:nodes test) node))))
     (Thread/sleep 3000)))
 
+(defn stop-raw!
+  [test node]
+  (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))
+
 (defn stop!
   "Shuts down server."
   [test node]
   (info node "Shutting down server node")
   (c/su
-    (util/meh (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))))
+    (util/meh (stop-raw! test node))))
 
 (defn nuke!
   "Shuts down server and destroys all data."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -66,7 +66,7 @@
                   (str "--meta-storage-node=" (node-name (:nodes test) node))))
     (Thread/sleep 3000)))
 
-(defn stop-raw!
+(defn stop-node!
   [test node]
   (c/cd (db-dir test) (c/exec "bin/ignite3db" "stop")))
 
@@ -74,7 +74,7 @@
   "Shuts down server."
   [test node]
   (info node "Shutting down server node")
-  (util/meh (stop-raw! test node)))
+  (util/meh (stop-node! test node)))
 
 (defn nuke!
   "Shuts down server and destroys all data."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -92,7 +92,7 @@
 
     db/LogFiles
     (log-files [_ test node]
-      (let [files (c/exec :find (db-dir test "log") :-type "f" :-name "ignite3*.log")]
+      (let [files (c/exec :find (db-dir test "log") :-type "f" :-name "ignite3*")]
         (info node files)
         (into [] (.split files "\n"))))))
 

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -45,11 +45,16 @@
     (c/exec :sed :-i (str "s/\"localhost:3344\"/" (clojure.string/join ", " (list-nodes all-nodes node)) "/")
                      (db-dir test "etc" "ignite-config.conf"))))
 
+(defn start-node!
+  "Start a single Ignite node"
+  [test node]
+  (info node "Starting server node")
+  (c/cd (db-dir test) (c/exec "bin/ignite3db" "start")))
+
 (defn start!
   "Starts server for the given node."
   [test node]
-  (info node "Starting server node")
-  (c/cd (db-dir test) (c/exec "bin/ignite3db" "start"))
+  (start-node! test node)
   (Thread/sleep 3000)
   (when (= 0 (.indexOf (:nodes test) node))
     (info node "Init cluster")

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -68,8 +68,7 @@
 
 (defn stop-raw!
   [test node]
-  (c/su
-    (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner")))
+  (c/cd (db-dir test) (c/exec "bin/ignite3db" "stop")))
 
 (defn stop!
   "Shuts down server."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -68,14 +68,14 @@
 
 (defn stop!
   "Shuts down server."
-  [node test]
+  [test node]
   (info node "Shutting down server node")
   (c/su
     (util/meh (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))))
 
 (defn nuke!
   "Shuts down server and destroys all data."
-  [node test]
+  [test node]
   (c/su
     (util/meh (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))
     (c/exec :rm :-rf server-dir)))
@@ -94,7 +94,7 @@
 
     (teardown! [_ test node]
       (info node "Teardown Apache Ignite" version)
-      (nuke! node test))
+      (nuke! test node))
 
     db/LogFiles
     (log-files [_ test node]

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -68,14 +68,14 @@
 
 (defn stop-raw!
   [test node]
-  (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner"))
+  (c/su
+    (c/exec :pkill :-9 :-f "org.apache.ignite.internal.app.IgniteRunner")))
 
 (defn stop!
   "Shuts down server."
   [test node]
   (info node "Shutting down server node")
-  (c/su
-    (util/meh (stop-raw! test node))))
+  (util/meh (stop-raw! test node)))
 
 (defn nuke!
   "Shuts down server and destroys all data."

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -110,13 +110,13 @@
 
 ; ---------- General scenario ----------
 
-(defn invoke-ops [^Ignite ignite acc ops]
+(defn invoke-ops [^Ignite ignite acc op]
   "Perform operations in a transaction."
   (let [txn (.begin (.transactions ignite))
         result (mapv #(case (first %)
                         :r       (read! acc ignite txn %)
                         :append  (append! acc ignite txn %))
-                     ops)]
+                     (:value op))]
     (.commit txn)
     result))
 
@@ -160,8 +160,7 @@
 
   (invoke! [this test op]
     (if connected
-      (let [ops   (:value op)
-            result (invoke-ops ignite acc ops)
+      (let [result (invoke-ops ignite acc op)
             overall-result (assoc op
                                   :type :info
                                   :value (into [] result))]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -131,6 +131,7 @@
 (defn invoke-ops [^Ignite ignite acc op]
   "Perform operations in a transaction."
   (try
+    ; (log/info "Ignite:" (.toString ignite))
     (let [txn (.begin (.transactions ignite))
           result (mapv #(case (first %)
                           :r       (read! acc ignite txn %)

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -10,9 +10,10 @@
                     [ignite3 :as ignite3]
                     [nemesis :as nemesis]]
             [jepsen.tests.cycle.append :as app])
-  (:import (org.apache.ignite Ignite)
-           (org.apache.ignite.client IgniteClient RetryLimitPolicy)
-           (org.apache.ignite.table.mapper Mapper)))
+  (:import (org.apache.ignite               Ignite)
+           (org.apache.ignite.client        IgniteClient RetryLimitPolicy)
+           (org.apache.ignite.sql           Statement)
+           (org.apache.ignite.table.mapper  Mapper)))
 
 ; ---------- Common definitions ----------
 
@@ -39,7 +40,10 @@
   "Run a SQL query. Return ResultSet instance that should be closed afterwards."
   ([sql query params] (run-sql sql nil query params))
   ([sql txn query params]
-    (log/info query params)
+    (let [printable-query (if (instance? Statement query)
+                              (.query query)
+                              query)]
+      (log/info printable-query params))
     (.execute sql txn query (object-array params))))
 
 (defn as-int-list [s]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -19,8 +19,6 @@
 
 (def table-name "APPEND")
 
-(def max-attempts 20)
-
 (defn sql-create-zone
   "Create replication zone with a given amount of table replicas"
   [replicas]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -115,13 +115,13 @@
   "Convert an exception into a known reason, or return nil."
   (let [msg (.getMessage exc)]
     (cond
-        (.contains msg "Failed to acquire a lock") ::deadlock-prevention
-        (.contains msg "Handshake timeout") ::handshake-timeout
-        (or (.contains msg "Failed to process replica request")
-            (.contains msg "Node left the cluster")
-            (.contains msg "The primary replica has changed")
-            (.contains msg "Unable to request next batch")
-            (.contains msg "Unable to send fragment")) ::not-connected
+        (.contains msg "Failed to acquire a lock")          ::deadlock-prevention
+        (.contains msg "Handshake timeout")                 ::handshake-timeout
+        (.contains msg "Node left the cluster")             ::node-left
+        (.contains msg "The primary replica has changed")   ::primary-replica-changed
+        (.contains msg "Failed to process replica request") ::failed-replica-request
+        (.contains msg "Unable to request next batch")      ::unable-request-batch
+        (.contains msg "Unable to send fragment")           ::unable-send-fragment
         :else nil)))
 
 (defn fail [op error]

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -138,11 +138,14 @@
 
 (defn print-table-content [ignite]
   "Save resulting table content in the log."
-  (with-open [rs (run-sql (.sql ignite) sql-select-all [])]
-    (log/info "Table content")
-    (while (.hasNext rs)
-      (let [row (.next rs)]
-        (log/info (.intValue row 0) ":" (.stringValue row 1))))))
+  (try
+    (with-open [rs (run-sql (.sql ignite) sql-select-all [])]
+      (log/info "Table content")
+      (while (.hasNext rs)
+        (let [row (.next rs)]
+          (log/info (.intValue row 0) ":" (.stringValue row 1)))))
+    (catch Exception e
+      (log/warn "Failed to get table content:" (.getMessage e)))))
 
 (defrecord Client [^Ignite ignite acc connected]
   client/Client

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -14,7 +14,7 @@
            (org.apache.ignite.client        IgniteClient
                                             IgniteClientConnectionException
                                             RetryLimitPolicy)
-           (org.apache.ignite.sql           Statement)
+           (org.apache.ignite.sql           Statement SqlException)
            (org.apache.ignite.table.mapper  Mapper)))
 
 ; ---------- Common definitions ----------
@@ -120,6 +120,10 @@
                        (:value op))]
       (.commit txn)
       (assoc op :type :info :value (into [] result)))
+    (catch SqlException e
+      (if (.contains (.getMessage e) "Failed to acquire a lock")
+        (assoc op :type :fail :error ::deadlock-prevention)
+        (throw e)))
     (catch IgniteClientConnectionException _
       (assoc op :type :fail :error ::not-connected))))
 

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -66,13 +66,13 @@
 
 (deftype SqlAccessor []
   Accessor
-  ;
+
   (read! [this ignite txn [opcode k v]]
     (let [r (with-open [rs (run-sql (.sql ignite) txn sql-select [k])]
               (let [s (if (.hasNext rs) (.stringValue (.next rs) 1) "")]
                 (as-int-list s)))]
       [:r k r]))
-  ;
+
   (append! [this ignite txn [opcode k v]]
     (with-open [read-rs (run-sql (.sql ignite) txn sql-select [k])]
       (if (.hasNext read-rs)
@@ -94,12 +94,12 @@
 
 (deftype KeyValueAccessor []
   Accessor
-  ;
+
   (read! [this ignite txn [opcode k v]]
     (let [view      (kv-view ignite)
           value     (as-int-list (.get view txn (int k)))]
       [:r k value]))
-  ;
+
   (append! [this ignite txn [opcode k v]]
     (let [view      (kv-view ignite)
           old-value (.get view txn (int k))

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -120,6 +120,7 @@
         (.contains msg "Node left the cluster")             ::node-left
         (.contains msg "The primary replica has changed")   ::primary-replica-changed
         (.contains msg "Failed to process replica request") ::failed-replica-request
+        (.contains msg "Replication is timed out")          ::replication-timeout
         (.contains msg "Unable to request next batch")      ::unable-request-batch
         (.contains msg "Unable to send fragment")           ::unable-send-fragment
         :else nil)))

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -116,6 +116,7 @@
   (let [msg (.getMessage exc)]
     (cond
         (.contains msg "Failed to acquire a lock") ::deadlock-prevention
+        (.contains msg "Handshake timeout") ::handshake-timeout
         (or (.contains msg "Failed to process replica request")
             (.contains msg "Node left the cluster")
             (.contains msg "The primary replica has changed")

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -118,7 +118,7 @@
                         :append  (append! acc ignite txn %))
                      (:value op))]
     (.commit txn)
-    result))
+    (assoc op :type :info :value (into [] result))))
 
 (defn print-table-content [ignite]
   "Save resulting table content in the log."
@@ -160,11 +160,7 @@
 
   (invoke! [this test op]
     (if connected
-      (let [result (invoke-ops ignite acc op)
-            overall-result (assoc op
-                                  :type :info
-                                  :value (into [] result))]
-        overall-result)
+      (invoke-ops ignite acc op)
       (assoc op :type :fail :error ::not-connected))))
 
 (comment "for repl"

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -127,9 +127,11 @@
     (catch SqlException e
       (cond
         (.contains (.getMessage e) "Failed to acquire a lock") (fail op ::deadlock-prevention)
-        (.contains (.getMessage e) "Failed to process replica request") (fail op ::not-connected)
-        (.contains (.getMessage e) "Unable to request next batch") (fail op ::not-connected)
-        (.contains (.getMessage e) "Unable to send fragment") (fail op ::not-connected)
+        (or (.contains (.getMessage e) "Failed to process replica request")
+            (.contains (.getMessage e) "Node left the cluster")
+            (.contains (.getMessage e) "The primary replica has changed")
+            (.contains (.getMessage e) "Unable to request next batch")
+            (.contains (.getMessage e) "Unable to send fragment")) (fail op ::not-connected)
         :else (throw e)))
     (catch IgniteClientConnectionException _
       (fail op ::not-connected))))

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -15,7 +15,8 @@
                                             IgniteClientConnectionException
                                             RetryLimitPolicy)
            (org.apache.ignite.sql           Statement SqlException)
-           (org.apache.ignite.table.mapper  Mapper)))
+           (org.apache.ignite.table.mapper  Mapper)
+           (org.apache.ignite.tx            TransactionException)))
 
 ; ---------- Common definitions ----------
 
@@ -133,6 +134,10 @@
             (.contains (.getMessage e) "Unable to request next batch")
             (.contains (.getMessage e) "Unable to send fragment")) (fail op ::not-connected)
         :else (throw e)))
+    (catch TransactionException e
+      (cond
+      (.contains (.getMessage e) "Failed to acquire a lock") (fail op ::deadlock-prevention)
+      :else (throw e)))
     (catch IgniteClientConnectionException _
       (fail op ::not-connected))))
 

--- a/ignite-3/src/jepsen/ignite3/append.clj
+++ b/ignite-3/src/jepsen/ignite3/append.clj
@@ -25,7 +25,7 @@
 (defn sql-create-zone
   "Create replication zone with a given amount of table replicas"
   [replicas]
-  (str "create zone if not exists \"" table-name "_zone\" with replicas=" replicas))
+  (str "create zone if not exists \"" table-name "_zone\" with storage_profiles='default', replicas=" replicas))
 
 (def sql-create (str "create table if not exists " table-name "(key int primary key, vals varchar(1000))"
                      " with PRIMARY_ZONE='" table-name "_zone'"))

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -22,7 +22,7 @@
    "restart"                (jepsen.nemesis/node-start-stopper
                               ignite-targeter
                               ign/stop!
-                              ign/start!)})
+                              ign/start-node!)})
 
 (def opt-spec
   "Command line options for tools.cli"

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging      :refer :all]
             [jepsen.cli                 :as jc]
             [jepsen.core                :as jepsen]
+            [jepsen.ignite3             :as ign]
             [jepsen.ignite3.append      :as append]
             [jepsen.ignite3.register    :as register]))
 
@@ -13,8 +14,15 @@
   {"append"     append/append-test
    "register"   register/register-test})
 
+(defn ignite-targeter [test nodes]
+  (first nodes))
+
 (def nemesis-types
-  {"noop"                   jepsen.nemesis/noop})
+  {"noop"                   jepsen.nemesis/noop
+   "restart"                (jepsen.nemesis/node-start-stopper
+                              ignite-targeter
+                              ign/stop!
+                              ign/start!)})
 
 (def opt-spec
   "Command line options for tools.cli"

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -23,7 +23,7 @@
                               ignite-targeter
                               (fn start
                                 [test node]
-                                (ign/stop-raw! test node)
+                                (ign/stop-node! test node)
                                 [:paused node])
                               (fn stop
                                 [test node]

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -21,8 +21,14 @@
   {"noop"                   jepsen.nemesis/noop
    "restart"                (jepsen.nemesis/node-start-stopper
                               ignite-targeter
-                              ign/stop-raw!
-                              ign/start-node!)})
+                              (fn start
+                                [test node]
+                                (ign/stop-raw! test node)
+                                [:paused node])
+                              (fn stop
+                                [test node]
+                                (ign/start-node! test node)
+                                [:resumed node]))})
 
 (def opt-spec
   "Command line options for tools.cli"

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -21,7 +21,7 @@
   {"noop"                   jepsen.nemesis/noop
    "restart"                (jepsen.nemesis/node-start-stopper
                               ignite-targeter
-                              ign/stop!
+                              ign/stop-raw!
                               ign/start-node!)})
 
 (def opt-spec

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -15,7 +15,7 @@
    "register"   register/register-test})
 
 (defn ignite-targeter [test nodes]
-  (first nodes))
+  (rand-nth nodes))
 
 (def nemesis-types
   {"noop"                   jepsen.nemesis/noop


### PR DESCRIPTION
Key changes:

1. Add a node-restarting nemesis (restart random node).
2. Create table `APPEND` in a distribution zone with proper amount of replicas.
3. Create `IgniteClient` instance for each request (in order to avoid resource draining).

Minor improvements:

1. Hide most of known exceptions, use error codes instead.
2. Properly print SQL queries when using `PreparedStatement`.
3. Remove minor asymmetry in API (`[node test]` vs `[test node]`).
4. Fix "create zone" syntax to support [IGNITE-21594](https://issues.apache.org/jira/browse/IGNITE-21594)