### PR TITLE
QA-4713 Automate Jepsen tests on TC

### DIFF
--- a/ignite-3/project.clj
+++ b/ignite-3/project.clj
@@ -7,6 +7,8 @@
                  [jepsen "0.3.4"]
                  [org.apache.ignite/ignite-client "3.0.0-SNAPSHOT"]
                  [org.apache.ignite/ignite-core "3.0.0-SNAPSHOT"]]
+  :profiles {:gg {:repositories
+                    [["gridgain-snapshots" "https://www.gridgainsystems.com/nexus/content/repositories/gridgain-snapshots/"]]}}
   :java-source-paths ["src/java"]
   :target-path "target/%s"
   :main jepsen.ignite3.runner

--- a/ignite-3/project.clj
+++ b/ignite-3/project.clj
@@ -7,8 +7,6 @@
                  [jepsen "0.3.4"]
                  [org.apache.ignite/ignite-client "3.0.0-SNAPSHOT"]
                  [org.apache.ignite/ignite-core "3.0.0-SNAPSHOT"]]
-  :profiles {:gg {:repositories
-                    [["gridgain-snapshots" "https://www.gridgainsystems.com/nexus/content/repositories/gridgain-snapshots/"]]}}
   :java-source-paths ["src/java"]
   :target-path "target/%s"
   :main jepsen.ignite3.runner

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -60,7 +60,7 @@
 (defn env-from [test]
   "Gets environment settings from test, if any, or empty list otherwise."
   (let [e (:environment test)]
-    (if (some? e) [(:env e)] [])))
+    (if (some? e) [:env e] [])))
 
 (defn db-starter-name [test]
   "Extracts the name of DB executable for test, as a list."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -87,12 +87,11 @@
 
 (defn init-command [test]
   "Create a list of params to be passed into 'ignite cluster init' CLI command."
-  (let [extra-opts  (remove empty? (clojure.string/split (get test :extra-init-options "") #" "))]
-    (concat (env-from test)
-            (cli-starter-name test)
-            ["cluster" "init"]
-            extra-opts
-            ["--name=ignite-cluster" (str "--metastorage-group=" (join-comma (cmg-nodes test)))])))
+  (concat (env-from test)
+          (cli-starter-name test)
+          ["cluster" "init"]
+          (remove empty? (clojure.string/split (get test :extra-init-options "") #" "))
+          ["--name=ignite-cluster" (str "--metastorage-group=" (join-comma (cmg-nodes test)))]))
 
 (defn start!
   "Starts server for the given node."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -86,7 +86,7 @@
     (map name-fn result-nodes)))
 
 (defn init-command [test]
-  "Create a list of params to be passed into 'ignite cluster init' CLI command."
+  "Create a full 'ignite cluster init' CLI command."
   (concat (env-from test)
           (cli-starter-name test)
           ["cluster" "init"]

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -64,7 +64,7 @@
   "Start a single Ignite node."
   [test node]
   (info node "Starting server node")
-  (c/cd (db-dir test) (c/exec "sh" "start-wrapper.sh" (get db-starter-name (:flavour test)))))
+  (c/cd (db-dir test) (c/exec :env (:environment test) "sh" "start-wrapper.sh" (get db-starter-name (:flavour test)))))
 
 (defn init-command [test]
   "Create a list of params to be passed into 'ignite cluster init' CLI command."
@@ -90,7 +90,9 @@
   ; Cluster must be initialized only once
   (when (= 0 (.indexOf (:nodes test) node))
     (let [init-args (init-command test)
-          params    (concat [(get cli-starter-name (:flavour test)) "cluster" "init"] init-args)]
+          params    (concat [:env (:environment test)
+                             (get cli-starter-name (:flavour test)) "cluster" "init"]
+                            init-args)]
       (info node "Init cluster as: " params)
       (c/cd (cli-dir test)
             (apply c/exec params)))

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -69,7 +69,7 @@
 (defn env-from [test]
   "Gets environment settings from test, if any, or empty list otherwise."
   (let [e (:environment test)]
-    (if (some? e) (:env e) [])))
+    (if (some? e) [(:env e)] [])))
 
 (defn cli-starter-name [test]
   "Extracts the name of CLI utility for test, as a list."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -113,7 +113,7 @@
 
 (defn stop-node!
   [test node]
-  (c/exec :pkill :-15 :-f "org.apache.ignite.internal.app.IgniteRunner"))
+  (c/su (c/exec :pkill :-15 :-f "org.apache.ignite.internal.app.IgniteRunner")))
 
 (defn stop!
   "Shuts down server."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -57,19 +57,23 @@
   (info node "Upload startup wrapper")
   (c/upload "bin/start-wrapper.sh" (db-dir test "start-wrapper.sh")))
 
-(def db-starter-name {"ignite3"     "bin/ignite3db"
-                      "gridgain9"   "bin/gridgain9db"})
+(defn env-from [test]
+  "Gets environment settings from test, if any, or empty list otherwise."
+  (let [e (:environment test)]
+    (if (some? e) [(:env e)] [])))
+
+(defn db-starter-name [test]
+  "Extracts the name of DB executable for test, as a list."
+  (list (get {"ignite3" "bin/ignite3db", "gridgain9" "bin/gridgain9db"}
+             (:flavour test))))
 
 (defn start-node!
   "Start a single Ignite node."
   [test node]
   (info node "Starting server node")
-  (c/cd (db-dir test) (c/exec :env (:environment test) "sh" "start-wrapper.sh" (get db-starter-name (:flavour test)))))
-
-(defn env-from [test]
-  "Gets environment settings from test, if any, or empty list otherwise."
-  (let [e (:environment test)]
-    (if (some? e) [(:env e)] [])))
+  (let [start-command (concat (env-from test)
+                              ["sh" "start-wrapper.sh" (db-starter-name test)])]
+    (c/cd (db-dir test) (apply c/exec start-command))))
 
 (defn cli-starter-name [test]
   "Extracts the name of CLI utility for test, as a list."

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -52,7 +52,7 @@
                      (db-dir test "etc" (get config-name (:flavour test))))))
 
 (defn upload-wrapper!
-  "Upload node startup wrapper to the node."
+  "Upload node startup wrapper to the node. TODO: try cu/start-daemon! instead"
   [test node]
   (info node "Upload startup wrapper")
   (c/upload "bin/start-wrapper.sh" (db-dir test "start-wrapper.sh")))

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -77,7 +77,7 @@
         ; use 1 storage node for cluster of 1-2 nodes, and 3 storage nodes for larger clusters
         cmg-size    (if (< 2 (count nodes)) 3 1)
         cmg-nodes   (take cmg-size nodes)]
-    (concat ["cluster" "init"]
+    (concat [(get cli-starter-name (:flavour test)) "cluster" "init"]
             extra-opts
             ["--name=ignite-cluster"
              (str "--metastorage-group=" (join-comma (map name-fn cmg-nodes)))])))
@@ -91,9 +91,7 @@
   ; Cluster must be initialized only once
   (when (= 0 (.indexOf (:nodes test) node))
     (let [init-args (init-command test)
-          params    (concat [:env (:environment test)
-                             (get cli-starter-name (:flavour test))]
-                            init-args)]
+          params    (concat [:env (:environment test)] init-args)]
       (info node "Init cluster as: " params)
       (c/cd (cli-dir test)
             (apply c/exec params)))

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -70,7 +70,7 @@
   "Create a list of params to be passed into 'ignite cluster init' CLI command."
   (let [nodes       (:nodes test)
         name-fn     (partial node-name nodes)
-        extra-opts  (clojure.string/split (:extra-init-options test) #" ")
+        extra-opts  (clojure.string/split (get test :extra-init-options "") #" ")
         ; use 1 storage node for cluster of 1-2 nodes, and 3 storage nodes for larger clusters
         cmg-size    (if (< 2 (count nodes)) 3 1)
         cmg-nodes   (take cmg-size nodes)]

--- a/ignite-3/src/jepsen/ignite3.clj
+++ b/ignite-3/src/jepsen/ignite3.clj
@@ -86,7 +86,7 @@
   [test node]
   (upload-wrapper! test node)
   (start-node! test node)
-  (Thread/sleep 3000)
+  (Thread/sleep 10000)
   ; Cluster must be initialized only once
   (when (= 0 (.indexOf (:nodes test) node))
     (let [init-args (init-command test)
@@ -94,7 +94,7 @@
       (info node "Init cluster as: " params)
       (c/cd (cli-dir test)
             (apply c/exec params)))
-    (Thread/sleep 3000)))
+    (Thread/sleep 10000)))
 
 (defn stop-node!
   [test node]

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -42,9 +42,9 @@
    [nil "--extra-init-options OPTIONS"
     "Extra options to be passed into cluster init command (see Ignite3 CLI docs)"
     :default ""]
-   [nil "--environment"
-    "Environment variables to pass into Ignite3 DB and CLI (like \"JAVA_HOME=..\""
-    :default ""]
+   [nil "--environment ENVIRONMENT"
+    "Environment variables to pass into Ignite3 DB and CLI (like \"JAVA_HOME=..\")"
+    :default nil]
    ["-o" "--os NAME" "Operating system: either centos, debian, or noop."
     :default  :noop
     :parse-fn keyword

--- a/ignite-3/src/jepsen/ignite3/runner.clj
+++ b/ignite-3/src/jepsen/ignite3/runner.clj
@@ -42,6 +42,9 @@
    [nil "--extra-init-options OPTIONS"
     "Extra options to be passed into cluster init command (see Ignite3 CLI docs)"
     :default ""]
+   [nil "--environment"
+    "Environment variables to pass into Ignite3 DB and CLI (like \"JAVA_HOME=..\""
+    :default ""]
    ["-o" "--os NAME" "Operating system: either centos, debian, or noop."
     :default  :noop
     :parse-fn keyword

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -18,19 +18,19 @@
           test3 {:nodes ["n1" "n2" "n3"]}
           test4 {:nodes ["n1" "n2" "n3" "n4"]}
           test5 {:nodes ["n1" "n2" "n3" "n4" "n5"]}]
-      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1"]
+      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test1)))
-      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1"]
+      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test2)))
-      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test3)))
-      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test4)))
-      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test5)))))
 
   (testing "Use of extra init options"
     (let [test1 {:nodes                 ["n1" "n2" "n3"]
                  :extra-init-options    "--config-files=my.conf"}]
-      (is (= ["--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["cluster" "init" "--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test1))))))

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -13,24 +13,25 @@
 
 (deftest init-command-test
   (testing "Generation of init command sequence"
-    (let [test1 {:nodes ["n1"]}
-          test2 {:nodes ["n1" "n2"]}
-          test3 {:nodes ["n1" "n2" "n3"]}
-          test4 {:nodes ["n1" "n2" "n3" "n4"]}
-          test5 {:nodes ["n1" "n2" "n3" "n4" "n5"]}]
-      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
+    (let [test1 {:flavour "ignite3" :nodes ["n1"]}
+          test2 {:flavour "ignite3" :nodes ["n1" "n2"]}
+          test3 {:flavour "ignite3" :nodes ["n1" "n2" "n3"]}
+          test4 {:flavour "ignite3" :nodes ["n1" "n2" "n3" "n4"]}
+          test5 {:flavour "ignite3" :nodes ["n1" "n2" "n3" "n4" "n5"]}]
+      (is (= ["bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test1)))
-      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
+      (is (= ["bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test2)))
-      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test3)))
-      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test4)))
-      (is (= ["cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test5)))))
 
   (testing "Use of extra init options"
-    (let [test1 {:nodes                 ["n1" "n2" "n3"]
+    (let [test1 {:flavour               "ignite3"
+                 :nodes                 ["n1" "n2" "n3"]
                  :extra-init-options    "--config-files=my.conf"}]
-      (is (= ["cluster" "init" "--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+      (is (= ["bin/ignite3" "cluster" "init" "--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test1))))))

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -34,4 +34,11 @@
                  :nodes                 ["n1" "n2" "n3"]
                  :extra-init-options    "--config-files=my.conf"}]
       (is (= ["bin/ignite3" "cluster" "init" "--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+             (init-command test1)))))
+
+  (testing "Pass custom environment"
+    (let [test1 {:flavour       "gridgain9"
+                 :nodes         ["n1"]
+                 :environment   "JAVA_HOME=/opt/java/jdk-open-11"}]
+      (is (= [:env "JAVA_HOME=/opt/java/jdk-open-11" "bin/gridgain9" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test1))))))

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -27,4 +27,10 @@
       (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test4)))
       (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
-             (init-command test5))))))
+             (init-command test5)))))
+
+  (testing "Use of extra init options"
+    (let [test1 {:nodes                 ["n1" "n2" "n3"]
+                 :extra-init-options    "--config-files=my.conf"}]
+      (is (= ["--config-files=my.conf" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
+             (init-command test1))))))

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -18,19 +18,13 @@
           test3 {:nodes ["n1" "n2" "n3"]}
           test4 {:nodes ["n1" "n2" "n3" "n4"]}
           test5 {:nodes ["n1" "n2" "n3" "n4" "n5"]}]
-      (is (= ["--cluster-name=ignite-cluster" "--meta-storage-node" "node-1"]
+      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test1)))
-      (is (= ["--cluster-name=ignite-cluster" "--meta-storage-node" "node-1"]
+      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1"]
              (init-command test2)))
-      (is (= ["--cluster-name=ignite-cluster" "--meta-storage-node" "node-1"
-                                              "--meta-storage-node" "node-2"
-                                              "--meta-storage-node" "node-3"]
+      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test3)))
-      (is (= ["--cluster-name=ignite-cluster" "--meta-storage-node" "node-1"
-                                              "--meta-storage-node" "node-2"
-                                              "--meta-storage-node" "node-3"]
+      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test4)))
-      (is (= ["--cluster-name=ignite-cluster" "--meta-storage-node" "node-1"
-                                              "--meta-storage-node" "node-2"
-                                              "--meta-storage-node" "node-3"]
+      (is (= ["" "--name=ignite-cluster" "--metastorage-group=node-1,node-2,node-3"]
              (init-command test5))))))

--- a/ignite-3/test/jepsen/ignite_test.clj
+++ b/ignite-3/test/jepsen/ignite_test.clj
@@ -39,6 +39,11 @@
   (testing "Pass custom environment"
     (let [test1 {:flavour       "gridgain9"
                  :nodes         ["n1"]
-                 :environment   "JAVA_HOME=/opt/java/jdk-open-11"}]
+                 :environment  "JAVA_HOME=/opt/java/jdk-open-11"}
+          test2 {:flavour       "ignite3"
+                 :nodes         ["n1"]
+                 :environment   "JAVA_HOME=/opt/java/jdk-open-17"}]
       (is (= [:env "JAVA_HOME=/opt/java/jdk-open-11" "bin/gridgain9" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
-             (init-command test1))))))
+             (init-command test1)))
+      (is (= [:env "JAVA_HOME=/opt/java/jdk-open-17" "bin/ignite3" "cluster" "init" "--name=ignite-cluster" "--metastorage-group=node-1"]
+             (init-command test2))))))


### PR DESCRIPTION
1. Add an ability to pass environment variables (like `JAVA_HOME`) to DB and CLI.
2. Fix unit tests (broken in the previous PR) and add new test cases.
3. Increase startup timeouts in order to make Jepsen test more stable.
4. Cleanup code for a bit: extract smaller functions, balance responsibility.